### PR TITLE
修复sm1.11无法加载

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: sourcemod
+          ref: 1.11-dev
           repository: alliedmodders/sourcemod
           submodules: recursive
 


### PR DESCRIPTION
sm的master分支为1.12，接口未向下兼容。
换成1.11编译后，1.12和1.11都能加载 